### PR TITLE
Rename "type" attribute to "schema_type"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,7 @@
       <artifactId>avro</artifactId>
       <version>${avro.version}</version>
     </dependency>
-
-
+    
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/org/schemata/domain/Schema.java
+++ b/src/main/java/org/schemata/domain/Schema.java
@@ -9,7 +9,7 @@ public record Schema(String name, String description, String comment, String see
 
   private Schema(Builder builder) {
     this(builder.name, builder.description, builder.comment, builder.seeAlso, builder.reference, builder.owner,
-        builder.domain, builder.status, builder.type.name(), builder.eventType.name(), builder.teamChannel,
+        builder.domain, builder.status, builder.schemaType.name(), builder.eventType.name(), builder.teamChannel,
         builder.alertChannel, builder.complianceOwner, builder.complianceChannel, builder.fieldList);
   }
 
@@ -22,7 +22,7 @@ public record Schema(String name, String description, String comment, String see
     String owner;
     String domain;
     String status;
-    Type type;
+    SchemaType schemaType;
     EventType eventType;
     String teamChannel;
     String alertChannel;
@@ -71,8 +71,8 @@ public record Schema(String name, String description, String comment, String see
       return this;
     }
 
-    public Builder type(String typeValue) {
-      this.type = Type.valueOf(typeValue);
+    public Builder schemaType(String schemaTypeValue) {
+      this.schemaType = SchemaType.valueOf(schemaTypeValue);
       return this;
     }
 

--- a/src/main/java/org/schemata/domain/SchemaType.java
+++ b/src/main/java/org/schemata/domain/SchemaType.java
@@ -1,5 +1,5 @@
 package org.schemata.domain;
 
-public enum Type {
+public enum SchemaType {
   ENTITY, EVENT, UNKNOWN
 }

--- a/src/main/java/org/schemata/provider/avro/AvroSchemaParser.java
+++ b/src/main/java/org/schemata/provider/avro/AvroSchemaParser.java
@@ -13,7 +13,7 @@ import java.util.stream.Stream;
 import org.schemata.domain.EventType;
 import org.schemata.domain.Field;
 import org.schemata.domain.Schema;
-import org.schemata.domain.Type;
+import org.schemata.domain.SchemaType;
 import org.schemata.exception.SchemaParserException;
 import org.schemata.provider.SchemaParser;
 
@@ -85,7 +85,7 @@ public class AvroSchemaParser implements SchemaParser {
     builder.owner(schema.getProp(Schema.Prop.OWNER));
     builder.domain(schema.getProp(Schema.Prop.DOMAIN));
     builder.status(schema.getProp(Schema.Prop.STATUS));
-    builder.type(handleEmptySchemaType(schema));
+    builder.schemaType(handleEmptySchemaType(schema));
     builder.eventType(handleEmptyEventType(schema));
     builder.teamChannel(schema.getProp(Schema.Prop.TEAM_CHANNEL));
     builder.alertChannel(schema.getProp(Schema.Prop.ALERT_CHANNEL));
@@ -113,7 +113,7 @@ public class AvroSchemaParser implements SchemaParser {
   }
 
   private String handleEmptySchemaType(org.apache.avro.Schema schema) {
-    return schema.getProp(Schema.Prop.SCHEMA_TYPE) == null ? Type.UNKNOWN.name()
+    return schema.getProp(Schema.Prop.SCHEMA_TYPE) == null ? SchemaType.UNKNOWN.name()
         : schema.getProp(Schema.Prop.SCHEMA_TYPE);
   }
 

--- a/src/main/java/org/schemata/provider/protobuf/ProtoProcessor.java
+++ b/src/main/java/org/schemata/provider/protobuf/ProtoProcessor.java
@@ -42,7 +42,7 @@ public class ProtoProcessor {
         }
         case "owner" -> builder.owner(Objects.toString(entry.getValue(), ""));
         case "domain" -> builder.domain(Objects.toString(entry.getValue(), ""));
-        case "type" -> builder.type(entry.getValue().toString());
+        case "schema_type" -> builder.schemaType(entry.getValue().toString());
         case "event_type" -> builder.eventType(entry.getValue().toString());
         case "status" -> builder.status(Objects.toString(entry.getValue(), ""));
         case "team_channel" -> builder.teamChannel(Objects.toString(entry.getValue(), ""));
@@ -86,8 +86,8 @@ public class ProtoProcessor {
   }
 
   private boolean isAnnotated(Descriptors.Descriptor descriptor) {
-    return !descriptor.getOptions().getExtension(org.schemata.schema.SchemataBuilder.type)
-        .equals(SchemataBuilder.Type.UNKNOWN);
+    return !descriptor.getOptions().getExtension(org.schemata.schema.SchemataBuilder.schemaType)
+        .equals(SchemataBuilder.SchemaType.UNKNOWN);
   }
 
   private boolean isPrimitiveType(Descriptors.FieldDescriptor.Type type, String typeName) {

--- a/src/main/java/org/schemata/validate/SchemaTrigger.java
+++ b/src/main/java/org/schemata/validate/SchemaTrigger.java
@@ -4,7 +4,7 @@ import java.util.function.Predicate;
 import org.apache.commons.lang3.StringUtils;
 import org.schemata.domain.Field;
 import org.schemata.domain.Schema;
-import org.schemata.domain.Type;
+import org.schemata.domain.SchemaType;
 
 
 public interface SchemaTrigger extends Predicate<Schema> {
@@ -15,10 +15,10 @@ public interface SchemaTrigger extends Predicate<Schema> {
 
   SchemaTrigger isDomainEmpty = schema -> StringUtils.isBlank(schema.domain());
 
-  SchemaTrigger isInValidType = schema -> Type.UNKNOWN.name().equalsIgnoreCase(schema.type());
+  SchemaTrigger isInValidType = schema -> SchemaType.UNKNOWN.name().equalsIgnoreCase(schema.type());
 
   SchemaTrigger isPrimaryKeyNotExistsForEntity = schema -> {
-    if (!schema.type().equalsIgnoreCase(Type.ENTITY.name())) {
+    if (!schema.type().equalsIgnoreCase(SchemaType.ENTITY.name())) {
       return false;
     }
     return schema.fieldList().stream().filter(Field::isPrimaryKey).count() != 1;

--- a/src/main/resources/schema/brand.proto
+++ b/src/main/resources/schema/brand.proto
@@ -14,7 +14,7 @@ message Brand {
   option(message_core).see_also = "db.brand MySQL table";
   option(owner) = "Platform";
   option(domain) = "Core";
-  option(type) = ENTITY;
+  option(schema_type) = ENTITY;
   option(team_channel) = "#team-platform";
   option(alert_channel) = "#alerts-platform";
 
@@ -33,7 +33,7 @@ message BrandEvent {
   option(message_core).description = "This is the description of the brand activity table";
   option(owner) = "Platform";
   option(domain) = "Core";
-  option(type) = EVENT;
+  option(schema_type) = EVENT;
   option(event_type) = LIFECYCLE;
   option(team_channel) = "#team-platform";
   option(alert_channel) = "#alerts-platform";

--- a/src/main/resources/schema/campaign.proto
+++ b/src/main/resources/schema/campaign.proto
@@ -22,7 +22,7 @@ message Campaign {
   option(message_core).see_also = "db.campaign MySQL table";
   option(owner) = "Marketing";
   option(domain) = "Growth";
-  option(type) = ENTITY;
+  option(schema_type) = ENTITY;
   option(team_channel) = "#team-growth";
   option(alert_channel) = "#alerts-growth";
 
@@ -41,7 +41,7 @@ message CampaignEvent {
   option(message_core).description = "This is the description of the Campaign activity table";
   option(owner) = "Marketing";
   option(domain) = "Growth";
-  option(type) = EVENT;
+  option(schema_type) = EVENT;
   option(event_type) = LIFECYCLE;
   option(team_channel) = "#team-growth";
   option(alert_channel) = "#alerts-growth";
@@ -60,7 +60,7 @@ message CampaignCategoryTrackerEvent {
   option(message_core).description = "This is the description of the Campaign activity table";
   option(owner) = "Marketing";
   option(domain) = "Growth";
-  option(type) = EVENT;
+  option(schema_type) = EVENT;
   option(event_type) = ACTIVITY;
   option(team_channel) = "#team-growth";
   option(alert_channel) = "#alerts-growth";
@@ -77,7 +77,7 @@ message CampaignProductTrackerEvent {
   option(message_core).description = "This is the description of the Campaign activity table";
   option(owner) = "Marketing";
   option(domain) = "Growth";
-  option(type) = EVENT;
+  option(schema_type) = EVENT;
   option(event_type) = ACTIVITY;
   option(team_channel) = "#team-growth";
   option(alert_channel) = "#alerts-growth";

--- a/src/main/resources/schema/category.proto
+++ b/src/main/resources/schema/category.proto
@@ -14,7 +14,7 @@ message Category {
   option(message_core).see_also = "db.category MySQL table";
   option(owner) = "Platform";
   option(domain) = "Core";
-  option(type) = ENTITY;
+  option(schema_type) = ENTITY;
   option(team_channel) = "#team-platform";
   option(alert_channel) = "#alerts-platform";
 
@@ -33,7 +33,7 @@ message CategoryEvent {
   option(message_core).description = "This is the description of the Category activity table";
   option(owner) = "Platform";
   option(domain) = "Core";
-  option(type) = EVENT;
+  option(schema_type) = EVENT;
   option(event_type) = LIFECYCLE;
   option(team_channel) = "#team-platform";
   option(alert_channel) = "#alerts-platform";

--- a/src/main/resources/schema/product.proto
+++ b/src/main/resources/schema/product.proto
@@ -16,7 +16,7 @@ message Product {
   option(message_core).see_also = "db.product MySQL table";
   option(owner) = "Platform";
   option(domain) = "Core";
-  option(type) = ENTITY;
+  option(schema_type) = ENTITY;
   option(team_channel) = "#team-platform";
   option(alert_channel) = "#alerts-platform";
 
@@ -41,7 +41,7 @@ message ProductEvent {
   option(message_core).description = "This is the description of the Product activity table";
   option(owner) = "Platform";
   option(domain) = "Core";
-  option(type) = EVENT;
+  option(schema_type) = EVENT;
   option(event_type) = LIFECYCLE;
   option(team_channel) = "#team-platform";
   option(alert_channel) = "#alerts-platform";

--- a/src/main/resources/schema/user.proto
+++ b/src/main/resources/schema/user.proto
@@ -22,7 +22,7 @@ message User {
   option(message_core).see_also = "db.user MySQL table";
   option(owner) = "Platform";
   option(domain) = "Core";
-  option(type) = ENTITY;
+  option(schema_type) = ENTITY;
   option(team_channel) = "#team-platform";
   option(alert_channel) = "#alerts-platform";
 
@@ -46,7 +46,7 @@ message UserEvent {
   option(message_core).description = "This is the description of the users table";
   option(owner) = "Platform";
   option(domain) = "Core";
-  option(type) = EVENT;
+  option(schema_type) = EVENT;
   option(event_type) = LIFECYCLE;
   option(team_channel) = "#team-platform";
   option(alert_channel) = "#alerts-platform";
@@ -67,7 +67,7 @@ message UserActivityEvent {
   option(message_core).description = "This is the description of the users table";
   option(owner) = "Product";
   option(domain) = "Growth";
-  option(type) = EVENT;
+  option(schema_type) = EVENT;
   option(event_type) = ACTIVITY;
   option(team_channel) = "#team-growth";
   option(alert_channel) = "#alerts-growth";
@@ -82,7 +82,7 @@ message UserActivityAggregate {
   option(message_core).description = "This is the aggregated user activity view count. The event aggregated by user & product";
   option(owner) = "Product";
   option(domain) = "Growth";
-  option(type) = EVENT;
+  option(schema_type) = EVENT;
   option(event_type) = AGGREGATED;
   option(team_channel) = "#team-growth";
   option(alert_channel) = "#alerts-growth";

--- a/src/org/schemata/protobuf/schemata.proto
+++ b/src/org/schemata/protobuf/schemata.proto
@@ -8,7 +8,7 @@ option java_package = "org.schemata.schema";
 option java_outer_classname = "SchemataBuilder";
 
 // MessageType captures the type of the stream. There are two types of stream.
-enum Type {
+enum SchemaType {
   // This is an invalid state. If the entity defined as unknown the validator should throw an exception.
   UNKNOWN = 0;
   //Entity streams can be mutated in the downstream services. Entity streams often used to represent the current
@@ -68,7 +68,7 @@ extend google.protobuf.MessageOptions {
   // Other possible domains are `sales`, `marketing`, `product` etc
   string domain = 60003;
   // Mandatory Metadata: define the type of the message.
-  Type type = 60004;
+  SchemaType schema_type = 60004;
   // Status of the entity. You can have `testing`, `production` or `staging` depends on the lifecycle of schema definition.
   string status = 60005;
   // Slack or Teams channel name to communicate with the team which owns ths entity

--- a/src/test/java/org/schemata/provider/avro/AvroSchemaParserTest.java
+++ b/src/test/java/org/schemata/provider/avro/AvroSchemaParserTest.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.schemata.ResourceLoader;
 import org.schemata.domain.EventType;
-import org.schemata.domain.Type;
+import org.schemata.domain.SchemaType;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -57,7 +57,7 @@ public class AvroSchemaParserTest {
     assertAll("Assert schema properties",
         () -> assertEquals("org.schemata.schema.Brand", schema.name()),
         () -> assertEquals("This is the description of the Brand table", schema.description()),
-        () -> assertEquals(Type.ENTITY.name(), schema.type()),
+        () -> assertEquals(SchemaType.ENTITY.name(), schema.type()),
         () -> assertEquals(EventType.NONE.name(), schema.eventType()),
         () -> assertEquals(3, schema.fieldList().size())
     );

--- a/src/test/java/org/schemata/validate/SchemaValidatorTest.java
+++ b/src/test/java/org/schemata/validate/SchemaValidatorTest.java
@@ -17,7 +17,7 @@ public class SchemaValidatorTest {
     builder.description("Schema Description");
     builder.owner("Growth");
     builder.domain("Core");
-    builder.type("ENTITY");
+    builder.schemaType("ENTITY");
     assertEquals(Status.ERROR, new SchemaValidator().apply(builder.build()).status());
   }
 
@@ -29,7 +29,7 @@ public class SchemaValidatorTest {
     builder.description("Schema Description");
     builder.owner("Growth");
     builder.domain("Core");
-    builder.type("ENTITY");
+    builder.schemaType("ENTITY");
     assertEquals(Status.SUCCESS, new SchemaValidator().apply(builder.build()).status());
   }
 
@@ -40,7 +40,7 @@ public class SchemaValidatorTest {
     builder.description("Schema Description");
     builder.owner("Growth");
     builder.domain("Core");
-    builder.type("EVENT");
+    builder.schemaType("EVENT");
     assertEquals(Status.SUCCESS, new SchemaValidator().apply(builder.build()).status());
   }
 
@@ -50,7 +50,7 @@ public class SchemaValidatorTest {
     Schema.Builder builder = new Schema.Builder("SchemaName", List.of(fieldBuilder.build()));
     builder.owner("Growth");
     builder.domain("Core");
-    builder.type("EVENT");
+    builder.schemaType("EVENT");
     assertEquals(Status.ERROR, new SchemaValidator().apply(builder.build()).status());
   }
 
@@ -60,7 +60,7 @@ public class SchemaValidatorTest {
     Schema.Builder builder = new Schema.Builder("SchemaName", List.of(fieldBuilder.build()));
     builder.description("Schema Description");
     builder.domain("Core");
-    builder.type("EVENT");
+    builder.schemaType("EVENT");
     assertEquals(Status.ERROR, new SchemaValidator().apply(builder.build()).status());
   }
 
@@ -70,7 +70,7 @@ public class SchemaValidatorTest {
     Schema.Builder builder = new Schema.Builder("SchemaName", List.of(fieldBuilder.build()));
     builder.description("Schema Description");
     builder.owner("Growth");
-    builder.type("EVENT");
+    builder.schemaType("EVENT");
     assertEquals(Status.ERROR, new SchemaValidator().apply(builder.build()).status());
   }
 }


### PR DESCRIPTION
Noticed "type" is a keyword in Avro. To bring uniformity, renaming the "type" field to "schema_type"